### PR TITLE
[mrp] Added config to allow overriding MRP params at runtime

### DIFF
--- a/src/messaging/ReliableMessageProtocolConfig.cpp
+++ b/src/messaging/ReliableMessageProtocolConfig.cpp
@@ -31,7 +31,7 @@ namespace chip {
 
 using namespace System::Clock::Literals;
 
-#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST || CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE
 static Optional<System::Clock::Timeout> idleRetransTimeoutOverride   = NullOptional;
 static Optional<System::Clock::Timeout> activeRetransTimeoutOverride = NullOptional;
 
@@ -72,7 +72,7 @@ Optional<ReliableMessageProtocolConfig> GetLocalMRPConfig()
     }
 #endif
 
-#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST  || CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE
     if (idleRetransTimeoutOverride.HasValue())
     {
         config.mIdleRetransTimeout = idleRetransTimeoutOverride.Value();

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -32,6 +32,20 @@
 namespace chip {
 
 /**
+ *  @def CHIP_CONFIG_RUNTIME_MRP_OVERRIDE
+ *
+ *  @brief
+ *    Enable overriding MRP params at runtime.
+ *
+ *  This config enables overriding MRP params at runtime which can be useful when the intervals may be various in different networks.
+ *  (e.g. different values of DTIM and beacon intervals in Wi-Fi network)
+ *
+ */
+#ifndef CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE
+#define CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE 0
+#endif
+
+/**
  *  @def CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
  *
  *  @brief
@@ -156,13 +170,13 @@ ReliableMessageProtocolConfig GetDefaultMRPConfig();
  */
 Optional<ReliableMessageProtocolConfig> GetLocalMRPConfig();
 
-#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST || CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE
 
 /**
  * @brief
  *
  * Overrides the local idle and active retransmission timeout parameters (which are usually set through compile
- * time defines). This is reserved for tests that need the ability to set these at runtime to make certain test scenarios possible.
+ * time defines).
  *
  */
 void OverrideLocalMRPConfig(System::Clock::Timeout idleRetransTimeout, System::Clock::Timeout activeRetransTimeout);

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -95,6 +95,8 @@ static_library("nrfconnect") {
       "wifi/WiFiManager.cpp",
       "wifi/WiFiManager.h",
     ]
+
+    public_deps += [ "${chip_root}/src/messaging:messaging_mrp_config" ]
   }
 
   if (chip_enable_nfc) {

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -26,6 +26,7 @@
 #include <inet/InetInterface.h>
 #include <inet/UDPEndPointImplSockets.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <messaging/ReliableMessageProtocolConfig.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/Zephyr/InetUtils.h>
 
@@ -45,10 +46,20 @@ extern "C" {
 extern char * net_sprint_ll_addr_buf(const uint8_t * ll, uint8_t ll_len, char * buf, int buflen);
 }
 
+// TODO When API for obtaining beacon interval and DTIM params is ready the following definitions can be removed
+#if CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE
+// The default value of Delivery Traffic Indication Message, a multiplier of the beacon interval.
+#define DEFAULT_DTIM_INTERVAL (3)
+// The default value of the beacon interval in miliseconds
+#define DEFAULT_BEACON_INTERVAL_MS (100_ms32)
+#endif
+
 namespace chip {
 namespace DeviceLayer {
 
 namespace {
+
+using namespace chip::System::Clock::Literals;
 
 NetworkCommissioning::WiFiScanResponse ToScanResponse(const wifi_scan_result * result)
 {
@@ -432,6 +443,12 @@ void WiFiManager::ConnectHandler(uint8_t * data)
             System::Clock::Milliseconds32(chip::Crypto::GetRandU16() % kMaxInitialRouterSolicitationDelayMs),
             SendRouterSolicitation, nullptr);
 
+        // TODO: When API for obtaining beacon interval and DTIM params is ready replace
+        // the (DEFAULT_DTIM_INTERVAL * DEFAULT_BEACON_INTERVAL_MS) defines with proper getters.
+#if CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE
+        OverrideLocalMRPConfig(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL + (DEFAULT_DTIM_INTERVAL * DEFAULT_BEACON_INTERVAL_MS),
+                               CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL + DEFAULT_DTIM_INTERVAL * DEFAULT_BEACON_INTERVAL_MS);
+#endif
         ChipLogDetail(DeviceLayer, "Connected to WiFi network");
         Instance().mWiFiState = WIFI_STATE_COMPLETED;
         if (Instance().mHandling.mOnConnectionSuccess)


### PR DESCRIPTION
Sometimes in different networks, it is needed to change MRP intervals at runtime. For example in low-power Wi-Fi networks when DTIM and beacon intervals may be various and depend on Access point settings.
The new config allows overriding MRP params at runtime by using the OverrideLocalMRPConfig() function, and clearing that override by using ClearLocalMRPConfigOverride().

